### PR TITLE
Add tests to check that directories and all contents are ignored

### DIFF
--- a/t/parse-gitignore.t
+++ b/t/parse-gitignore.t
@@ -12,6 +12,8 @@ my $pg = Parse::Gitignore->new ('test-gitignore',
 ok ($pg->ignored ('monkeyshines'), "Ignored glob 'monkey*'");
 ok ($pg->ignored ('starfruit'), "Ignored glob '*fruit'");
 ok (! $pg->ignored ('nice'), "Did not ignore 'nice'");
+ok ($pg->ignored ('bin/'), "Ignored the bin/ directory");
+ok ($pg->ignored ('bin/isotope'), "Ignored a file in the bin/ directory");
 
 done_testing ();
 # Local variables:

--- a/t/test-files/test-gitignore
+++ b/t/test-files/test-gitignore
@@ -2,3 +2,5 @@
 *fruit
 # nice
 monkey*
+# Exclude everything in a bin/ directory
+bin/


### PR DESCRIPTION
Add tests to check that directories and all contents are ignored when given a slash suffix.